### PR TITLE
Changed "export default" to "module.exports" to fix jest error

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,15 +2,13 @@
  * @see https://github.com/vuejs/vue/commit/a855dd0564a657a73b7249469490d39817f27cf7#diff-c0a2623ea5896a83e3b630f236b47b52
  * @see https://stackoverflow.com/a/13091266/4936667
  */
-
-var decoder;
-
-export default function decode(html) {
+let decoder;
+module.exports = function(html) {
     decoder = decoder || document.createElement('div');
     // Escape HTML before decoding for HTML Entities
     html = escape(html).replace(/%26/g,'&').replace(/%23/g,'#').replace(/%3B/g,';');
     // decoding
     decoder.innerHTML = html;
-
     return unescape(decoder.textContent);
 }
+

--- a/package.json
+++ b/package.json
@@ -13,18 +13,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/joshmocek/entity-decode.git"
+    "url": "git+https://github.com/shrpne/entity-decode.git"
   },
   "keywords": [
     "entity",
     "decode"
   ],
-  "author": "joshmocek",
+  "author": "shrpne",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/joshmocek/entity-decode/issues"
+    "url": "https://github.com/shrpne/entity-decode/issues"
   },
-  "homepage": "https://github.com/joshmocek/entity-decode#readme",
+  "homepage": "https://github.com/shrpne/entity-decode#readme",
   "dependencies": {
     "he": "^1.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entity-decode",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Environment agnostic entity decoder",
   "main": "node.js",
   "browser": "browser.js",
@@ -13,18 +13,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shrpne/entity-decode.git"
+    "url": "git+https://github.com/joshmocek/entity-decode.git"
   },
   "keywords": [
     "entity",
     "decode"
   ],
-  "author": "shrpne",
+  "author": "joshmocek",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/shrpne/entity-decode/issues"
+    "url": "https://github.com/joshmocek/entity-decode/issues"
   },
-  "homepage": "https://github.com/shrpne/entity-decode#readme",
+  "homepage": "https://github.com/joshmocek/entity-decode#readme",
   "dependencies": {
     "he": "^1.1.1"
   }


### PR DESCRIPTION
When using in a project that tests with jest the file cannot be transformed because it is using `export default function` instead of `module.exports = function`.

```
export default function decode(html) {
    ^^^^^^
    SyntaxError: Unexpected token 'export' 
      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:537:17)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:579:25)
```
